### PR TITLE
use public directory for landing page image

### DIFF
--- a/src/components/LandingPage.jsx
+++ b/src/components/LandingPage.jsx
@@ -17,14 +17,17 @@ export default function Search() {
   // react-select async searchbar style
 
   return (
-    <div className="flex flex-col justify-center h-screen bg-hero bg-cover font-display ">
-      <h1 className="text-center text-8xl drop-shadow-lg brightness-100 text-white">SEARCH FOR COCKTAILS</h1>
-      <Searchbar
-        onChange={handleOnChange}
-        placeholder={"Cocktails"}
-        className={"bg-grey-300 w-4/12 pt-5 mx-auto text-2xl "}
-        styles={SearchBarStyle}
-      />
+    <div className="h-screen flex flex-col justify-center">
+      <div className="absolute inset-0 bg-hero bg-cover grayscale opacity-25" />
+      <div className="font-display">
+        <h1 className="text-center text-8xl drop-shadow-lg brightness-100 text-white">SEARCH FOR COCKTAILS</h1>
+        <Searchbar
+          onChange={handleOnChange}
+          placeholder={"Cocktails"}
+          className={"bg-grey-300 w-4/12 pt-5 mx-auto text-2xl "}
+          styles={SearchBarStyle}
+          />
+      </div>
     </div>
   );
 }

--- a/src/index.css
+++ b/src/index.css
@@ -5,5 +5,7 @@
 @layer base {
   html {
     @apply scroll-smooth;
+
+    color-scheme: dark;
   }
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -8,7 +8,7 @@ export default {
         text: ["Poppins", "sans-serif"],
       },
       backgroundImage: {
-        hero: "url('src/assets/landingPage/blackBarBackground3.png')",
+        hero: "url('/landingPage/blackBarBackground3.png')",
       },
     },
   },


### PR DESCRIPTION
Hey, regarding this https://github.com/sitek94/vite-deploy-demo/issues/6, I see that there is still problem with loading landing page image. 

The problem is with the url: 
![screen 2023-06-21 at 18 46 02](https://github.com/shoeslace911/the-black-bar/assets/58401630/181a2300-245b-45d0-96db-009a54574002)

After building the app there is a warning about it:

![screen 2023-06-21 at 18 39 43](https://github.com/shoeslace911/the-black-bar/assets/58401630/650a3b4f-e717-45c4-b098-8895431b3509)

If you want to test it without deploying you can do:

```
npm run build 
npm run preview
```

It will simulate the production build of the app. 

---

You can fix this issue by moving landing page image to `public` directory.

It works for me:
![screen 2023-06-21 at 18 40 59](https://github.com/shoeslace911/the-black-bar/assets/58401630/aac58e73-54dc-42c3-8c8c-3c23a5841fd5)

---

https://vitejs.dev/guide/assets.html#the-public-directory