### PR TITLE
improve landing page contrast

### DIFF
--- a/src/components/LandingPage.jsx
+++ b/src/components/LandingPage.jsx
@@ -17,14 +17,17 @@ export default function Search() {
   // react-select async searchbar style
 
   return (
-    <div className="flex flex-col justify-center h-screen bg-hero bg-cover font-display ">
-      <h1 className="text-center text-8xl drop-shadow-lg brightness-100 text-white">SEARCH FOR COCKTAILS</h1>
-      <Searchbar
-        onChange={handleOnChange}
-        placeholder={"Cocktails"}
-        className={"bg-grey-300 w-4/12 pt-5 mx-auto text-2xl "}
-        styles={SearchBarStyle}
-      />
+    <div className="h-screen flex flex-col justify-center">
+      <div className="absolute inset-0 bg-hero bg-cover grayscale opacity-25" />
+      <div className="font-display">
+        <h1 className="text-center text-8xl drop-shadow-lg brightness-100 text-white">SEARCH FOR COCKTAILS</h1>
+        <Searchbar
+          onChange={handleOnChange}
+          placeholder={"Cocktails"}
+          className={"bg-grey-300 w-4/12 pt-5 mx-auto text-2xl "}
+          styles={SearchBarStyle}
+          />
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
Hey, here's another suggestion. 

You could play around with colors of landing page background image, e.g. lower the opacity and use the grayscale to pop the navigation, heading and search bar. It plays especially nicely with this orange accent that you've got in the navigation:

![screen 2023-06-21 at 19 09 11](https://github.com/shoeslace911/the-black-bar/assets/58401630/f97c9e05-8b79-4f06-8c87-eabfa2730cf0)

![screen 2023-06-21 at 19 15 29](https://github.com/shoeslace911/the-black-bar/assets/58401630/10733c96-e08c-456a-8e6d-36a0a3f66837)

---

Here are relevant Tailwind classes:
https://tailwindcss.com/docs/grayscale
